### PR TITLE
New VMs: SSH auth by private key instead of password

### DIFF
--- a/azure/new-vm.arm.json
+++ b/azure/new-vm.arm.json
@@ -45,10 +45,10 @@
         "description": "Username to login to the Virtual Machine."
       }
     },
-    "sshPublicKeys": {
-      "type": "array",
+    "sshPublicKey": {
+      "type": "String",
       "metadata": {
-        "description": "List of SSH public keys for VM access; in the Portal type as a JSON list of Strings."
+        "description": "SSH public keys for VM access"
       }
     }
   },
@@ -207,14 +207,8 @@
               "enabled": true,
               "publicKeys": [
                 {
-                  "copy": {
-                    "name": "sshKeyLoop",
-                    "count": "[length(parameters('sshPublicKeys'))]",
-                    "input": {
-                      "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
-                      "keyData": "[parameters('sshPublicKeys')[copyIndex()]]"
-                    }
-                  }
+                  "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
+                  "keyData": "[parameters('sshPublicKey')]"
                 }
               ]
             },

--- a/azure/new-vm.arm.json
+++ b/azure/new-vm.arm.json
@@ -45,11 +45,10 @@
         "description": "Username to login to the Virtual Machine."
       }
     },
-    "adminPassword": {
-      "type": "securestring",
-      "minLength": 16,
+    "sshPublicKeys": {
+      "type": "array",
       "metadata": {
-        "description": "Password to login to the Virtual Machine. Must be 16+ characters"
+        "description": "List of SSH public keys for VM access; in the Portal type as a JSON list of Strings."
       }
     }
   },
@@ -202,9 +201,23 @@
           "allowExtensionOperations": true,
           "computerName": "[parameters('vmName')]",
           "adminUsername": "[parameters('adminUsername')]",
-          "adminPassword": "[parameters('adminPassword')]",
           "linuxConfiguration": {
-            "disablePasswordAuthentication": false,
+            "disablePasswordAuthentication": true,
+            "ssh": {
+              "enabled": true,
+              "publicKeys": [
+                {
+                  "copy": {
+                    "name": "sshKeyLoop",
+                    "count": "[length(parameters('sshPublicKeys'))]",
+                    "input": {
+                      "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
+                      "keyData": "[parameters('sshPublicKeys')[copyIndex()]]"
+                    }
+                  }
+                }
+              ]
+            },
             "patchSettings": {
               "assessmentMode": "ImageDefault",
               "patchMode": "ImageDefault"

--- a/build/azure/new-vm.arm.json
+++ b/build/azure/new-vm.arm.json
@@ -45,10 +45,10 @@
         "description": "Username to login to the Virtual Machine."
       }
     },
-    "sshPublicKeys": {
-      "type": "array",
+    "sshPublicKey": {
+      "type": "String",
       "metadata": {
-        "description": "List of SSH public keys for VM access; in the Portal type as a JSON list of Strings."
+        "description": "SSH public keys for VM access"
       }
     }
   },
@@ -207,14 +207,8 @@
               "enabled": true,
               "publicKeys": [
                 {
-                  "copy": {
-                    "name": "sshKeyLoop",
-                    "count": "[length(parameters('sshPublicKeys'))]",
-                    "input": {
-                      "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
-                      "keyData": "[parameters('sshPublicKeys')[copyIndex()]]"
-                    }
-                  }
+                  "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
+                  "keyData": "[parameters('sshPublicKey')]"
                 }
               ]
             },

--- a/build/azure/new-vm.arm.json
+++ b/build/azure/new-vm.arm.json
@@ -45,11 +45,10 @@
         "description": "Username to login to the Virtual Machine."
       }
     },
-    "adminPassword": {
-      "type": "securestring",
-      "minLength": 16,
+    "sshPublicKeys": {
+      "type": "array",
       "metadata": {
-        "description": "Password to login to the Virtual Machine. Must be 16+ characters"
+        "description": "List of SSH public keys for VM access; in the Portal type as a JSON list of Strings."
       }
     }
   },
@@ -202,9 +201,23 @@
           "allowExtensionOperations": true,
           "computerName": "[parameters('vmName')]",
           "adminUsername": "[parameters('adminUsername')]",
-          "adminPassword": "[parameters('adminPassword')]",
           "linuxConfiguration": {
-            "disablePasswordAuthentication": false,
+            "disablePasswordAuthentication": true,
+            "ssh": {
+              "enabled": true,
+              "publicKeys": [
+                {
+                  "copy": {
+                    "name": "sshKeyLoop",
+                    "count": "[length(parameters('sshPublicKeys'))]",
+                    "input": {
+                      "path": "[concat('/home/', parameters('adminUsername'), '/.ssh/authorized_keys')]",
+                      "keyData": "[parameters('sshPublicKeys')[copyIndex()]]"
+                    }
+                  }
+                }
+              ]
+            },
             "patchSettings": {
               "assessmentMode": "ImageDefault",
               "patchMode": "ImageDefault"


### PR DESCRIPTION
All new VMs will require SSH key authentication. Password login will be disabled by default.

Azure portal provides a nice UI when it sees a parameter called `sshPublicKey`: it lets you pick whether to paste a public key, choose one already stored in Azure, or generate a new one.

A downside is that this only automates adding ONE ssh key-- so if you need more you need to add it manually after VM creation.
