### PR TITLE
Update Comapeo Cloud Docker image to community first

### DIFF
--- a/caprover/one-click-apps/v4/apps/comapeo-cloud.yml
+++ b/caprover/one-click-apps/v4/apps/comapeo-cloud.yml
@@ -29,8 +29,8 @@ caproverOneClickApp:
   variables:
   - id: '$$cap_comapeocloud_docker_image'
     label: CoMapeo Archive Server Docker Image
-    defaultValue: 'guardiancr.azurecr.io/comapeo-cloud:20250128-1545'
-    validRegex: /^guardiancr.azurecr.io/comapeo-cloud:[0-9a-z_-]+$/
+    defaultValue: 'communityfirst/comapeo-cloud:0.2.1'
+    validRegex: /^communityfirst/comapeo-cloud:[0-9a-z_-]+$/
     description: Check out the container registry for valid tags
 
   - id: '$$cap_server_bearer_token'


### PR DESCRIPTION
RE: this comment https://github.com/ConservationMetrics/gc-deploy/pull/9#discussion_r2240686701

I thought we had done this already, but I had merely written about it in https://github.com/ConservationMetrics/gc-deploy/issues/5.

This PR changes the default Docker image source for CoMapeo Cloud to https://hub.docker.com/r/communityfirst/comapeo-cloud, but still allows the user to change it for e.g. control over the image tag version