### PR TITLE
Tune Windmill DATABASE_CONNECTIONS

### DIFF
--- a/caprover/one-click-apps/v4/apps/windmill-only.yml
+++ b/caprover/one-click-apps/v4/apps/windmill-only.yml
@@ -138,12 +138,12 @@ caproverOneClickApp:
 
         - id: $$cap_server_database_connections
           label: The max number of connections in the server's database connection pool
-          defaultValue: 10
+          defaultValue: 5
           validRegex: /^[1-9][0-9]?$/
 
         - id: $$cap_worker_database_connections
           label: The max number of connections in a worker's database connection pool.
-          defaultValue: 3
+          defaultValue: 5
           description: |-
               Note that there are multiple worker processes, each one creating its own pool.
               This value is per worker.


### PR DESCRIPTION
### Goal
This PR brings our one-click app's default values in-line with what we've tuned in existing deployments

### What I changed

when worker has just 3 connections, it is unable to do simple stuff like schedule the next execution
* See https://github.com/ConservationMetrics/gc-programs/issues/38#issuecomment-2786669515


when server doesn't need as many as 10 connections; this commit reduces it to 5, which is also what superset web server uses
* See https://github.com/ConservationMetrics/gc-programs/issues/36#issuecomment-2786495619