### PR TITLE
Drop windmill-lsp from "windmill-only" one-click-app.

### DIFF
--- a/caprover/INSTALL_GC_STACK.md
+++ b/caprover/INSTALL_GC_STACK.md
@@ -170,24 +170,26 @@ These commands can be found inside the `stack_deploy.py` script and include crea
 
 #### After Install
 
+
 ##### Code assistants
 
 To enable [code assistants](https://www.windmill.dev/docs/code_editor/assistants),
-please change the following settings before using the service (Change `windmill` in the codeblock to
-the app name you gave it):
+you will need to install the Language Server Protocol (LSP):
 
-1. Go to the settings for the app.
-2. Ensure **Websocket Support** is enabled.
-3. Ensure **Force HTTPS** is enabled.
-4. Click on **Edit Default Nginx Configurations** and paste the following content before the last closing bracket "}":
-    ```
-    location /ws/ {
-        proxy_pass http://srv-captain--windmill-lsp:3001/ws/;
-        proxy_http_version 1.1;
-        proxy_set_header Upgrade $http_upgrade;
-        proxy_set_header Connection "upgrade";
-    }
-    ```
+1. Deploy a new Caprover App, the Windmill LSP: `ghcr.io/windmill-labs/windmill-lsp:1.518.2`
+2. Route Windmill HTTP requests intended for LSP:
+    1. Go to the settings for the core windmill web server
+    2. Ensure **Websocket Support** is enabled.
+    3. Ensure **Force HTTPS** is enabled.
+    4. Click on **Edit Default Nginx Configurations** and paste the following content before the last closing bracket "}" (Change `windmill-lsp` in the codeblock to the app name you gave it):
+        ```
+        location /ws/ {
+            proxy_pass http://srv-captain--windmill-lsp:3001/ws/;
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+        }
+        ```
 
 ##### For first-time login:
 

--- a/caprover/one-click-apps/v4/apps/windmill-only.yml
+++ b/caprover/one-click-apps/v4/apps/windmill-only.yml
@@ -44,16 +44,6 @@ services:
         caproverExtra:
             notExposeAsWebApp: 'true'
 
-    $$cap_appname-lsp:
-        image: ghcr.io/windmill-labs/windmill-lsp:latest  # some labels appear broken
-        volumes:
-            - $$cap_appname-lsp-cache:/root/.cache
-        expose:
-            - 3001
-        caproverExtra:
-            containerHttpPort: 3001
-            notExposeAsWebApp: 'true'
-
 caproverOneClickApp:
     instructions:
         start: |-
@@ -101,22 +91,13 @@ caproverOneClickApp:
         end: |-
             Windmill has been successfully deployed!
 
-            Please change the following settings before using the service:
-            1. Go to the settings for `$$cap_appname`
-            2. Enable **Websocket Support**
-            3. Enable **HTTPS**
-            4. Click on **Edit Default Nginx Configurations** and paste the following content before the last closing bracket "}":
-                ```
-                location /ws/ {
-                    proxy_pass http://srv-captain--$$cap_appname-lsp:3001/ws/;
-                    proxy_http_version 1.1;
-                    proxy_set_header Upgrade $http_upgrade;
-                    proxy_set_header Connection "upgrade";
-                }
-                ```
             Now you can access it at `https://$$cap_appname.$$cap_root_domain`
 
             Follow the instructions for first-time login: https://www.windmill.dev/docs/advanced/self_host#first-time-login
+
+            Language Server Protocol (LSP) support was not installed. If you desire code assistants
+            and additional language-specific functionality, follow the instructions at
+            https://github.com/ConservationMetrics/gc-deploy/blob/main/caprover/INSTALL_GC_STACK.md#code-assistants
 
     displayName: Windmill - No Database
     isOfficial: true

--- a/caprover/stack_deploy.py
+++ b/caprover/stack_deploy.py
@@ -150,7 +150,6 @@ def deploy_stack(config, gc_repository, dry_run):
             )
             cap.enable_ssl(app_name)
             cap.update_app(app_name, force_ssl=True, support_websocket=True)
-            input("INSTALL IS NOT FINISHED -  YOU MUST EDIT THE CUSTOM NGINX CONFIG!")
 
     # Deploy Redis if specified in config
     one_click_app_name = "redis"


### PR DESCRIPTION
I've found windmill-lsp a bit of a headache to install. For example
- not clear what image tag to use (at least at some point last year the tag that matched the core windmill image was incompatible or broken)
- requires manual step to edit NGINX config
- even when install "goes right" i'm not convinced all features actually worked in the app.

So after this PR, the `windmill-only` one-click-app will not install LSP.  There remain instructions to manually install it yourself.