### PR TITLE
More stack_deploy tweaks

### DIFF
--- a/caprover/INSTALL_GC_STACK.md
+++ b/caprover/INSTALL_GC_STACK.md
@@ -91,10 +91,10 @@ If you don't want to sweat the details, it's much quicker to deploy the Guardian
 Set up a Python environment:
 
 ```sh
-git clone git@github.com:IamJeffG/Caprover-API.git
+git clone https://github.com/IamJeffG/Caprover-API.git
+cd Caprover-API/
 git checkout fix-oneclick-repo
-python setup.py install
-pip install 'psycopg[binary]'
+pip install 'psycopg[binary]' .
 ```
 
 The `stack_deploy.py` script requires you to create a `stack.yaml` file of variable values by

--- a/caprover/stack_deploy.py
+++ b/caprover/stack_deploy.py
@@ -64,7 +64,6 @@ def deploy_stack(config, gc_repository, dry_run):
         if not dry_run:
             cap.deploy_one_click_app(
                 one_click_app_name="postgres",
-                namespace=None,
                 app_variables=postgres_variables,
                 automated=True,
             )

--- a/caprover/stack_deploy.py
+++ b/caprover/stack_deploy.py
@@ -304,7 +304,7 @@ def deploy_stack(config, gc_repository, dry_run):
                 ],
                 # NOTE: You will get warning pages in the filebrowser app before the `datalake` subdir is created in storage:
                 # https://github.com/ConservationMetrics/gc-deploy/pull/12#discussion_r2243697895
-                environment_variables={"FB_ROOT": "/mnt/persistent-storage/datalake"},
+                environment_variables={"FB_ROOT": "/srv/datalake"},
             )
 
             if redirect_from_domain := config[one_click_app_name].get(

--- a/caprover/stack_deploy.py
+++ b/caprover/stack_deploy.py
@@ -325,6 +325,7 @@ def main():
     parser.add_argument(
         "-c",
         "--config-file",
+        required=True,
         help="Path to configuration YAML file (copy stack.example.yaml)",
     )
     parser.add_argument(


### PR DESCRIPTION
More minor improvements or bugfixes to stack_deploy.py

* 4fc985f Drop use of deprecated namespace= param by the CapRover API
* 44f61fd Script now REQUIRES `--config-file` arg
* 3277ed7 More reliable venv install for stack_deploy.py
    -  Git http URL to avoid key errors when no keys are set up
    - '`pip install .`' for when 'setuptools' is missing
* 838c8db Bugfix: Filebrowser FB_ROOT uses in-app path
