### PR TITLE
E2E test also deploys webapps

### DIFF
--- a/caprover/stack.test.yaml
+++ b/caprover/stack.test.yaml
@@ -1,6 +1,7 @@
 # caproverUrl hostname is hard-coded in `install-caprover.sh`
 caproverUrl: "http://captain.test-gc-deploy.localhost"
 caproverPassword: "captain42"  # the Caprover default
+webappsUseSsl: false
 
 postgres:
   deploy: true  # Use internal postgres for testing
@@ -21,11 +22,12 @@ superset-only:
   deploy: false  # Skip superset for faster testing
 
 gc-explorer:
-  deploy: false  # Skip gcexplorer for faster testing
+  deploy: true
+  postgres_database: "warehouse"
 
 comapeo-cloud:
-  deploy: false  # Skip comapeo for faster testing
+  deploy: true
 
 filebrowser:
-  deploy: false  # Test a simple service
+  deploy: true
   app_name: files-test

--- a/caprover/stack.test.yaml
+++ b/caprover/stack.test.yaml
@@ -10,16 +10,18 @@ postgres:
   database: postgres
   version: 16
 
+redis:
+  deploy: true
+  app_name: test-redis
+  redis_password: "test-redis-key"
+
 windmill-only:
   deploy: false  # Skip windmill for faster testing
 
-redis:
-  deploy: true
-  app_name: redis-test
-  redis_password: "test-redis-key"
-
 superset-only:
-  deploy: false  # Skip superset for faster testing
+  deploy: false  # Skip windmill for faster testing
+  redis_url: "redis://:test-redis-key@srv-captain--test-redis:6379"
+  redis_key_prefix: ""
 
 gc-explorer:
   deploy: true
@@ -27,7 +29,8 @@ gc-explorer:
 
 comapeo-cloud:
   deploy: true
+  app_name: test-comapeo
 
 filebrowser:
   deploy: true
-  app_name: files-test
+  app_name: test-files

--- a/caprover/stack_deploy.py
+++ b/caprover/stack_deploy.py
@@ -69,6 +69,7 @@ def deploy_stack(config, gc_repository, dry_run):
     cap = caprover_api.CaproverAPI(
         dashboard_url=config.get("caproverUrl"), password=config.get("caproverPassword")
     )
+    webapps_ssl = config.get("webappsUseSsl", True)
 
     # Deploy PostgreSQL if specified in config
     if config["postgres"].get("deploy", False):
@@ -180,8 +181,11 @@ def deploy_stack(config, gc_repository, dry_run):
                 automated=True,
                 one_click_repository=gc_repository,
             )
-            cap.enable_ssl(app_name)
-            cap.update_app(app_name, force_ssl=True, support_websocket=True)
+            cap.update_app(app_name, support_websocket=True)
+            if webapps_ssl:
+                cap.enable_ssl(app_name)
+                cap.update_app(app_name, force_ssl=True)
+
 
     # Deploy Redis if specified in config
     one_click_app_name = "redis"
@@ -224,9 +228,10 @@ def deploy_stack(config, gc_repository, dry_run):
                 automated=True,
                 one_click_repository=gc_repository,
             )
-            cap.enable_ssl(app_name)
+            if webapps_ssl:
+                cap.enable_ssl(app_name)
             cap.update_app(
-                app_name, force_ssl=True, redirectDomain=f"{app_name}.{cap.root_domain}"
+                app_name, force_ssl=webapps_ssl, redirectDomain=f"{app_name}.{cap.root_domain}"
             )
 
             # disable the healthcheck in Service Update Override, which will be maintained
@@ -256,8 +261,9 @@ def deploy_stack(config, gc_repository, dry_run):
                 automated=True,
                 one_click_repository=gc_repository,
             )
-            cap.enable_ssl(app_name)
-            cap.update_app(app_name, force_ssl=True)
+            if webapps_ssl:
+                cap.enable_ssl(app_name)
+                cap.update_app(app_name, force_ssl=True)
 
         if redirect_to_root:
             logger.info(
@@ -265,7 +271,8 @@ def deploy_stack(config, gc_repository, dry_run):
             )
             if not dry_run:
                 cap.add_domain(app_name, cap.root_domain)
-                cap.enable_ssl(app_name, cap.root_domain)
+                if webapps_ssl:
+                    cap.enable_ssl(app_name, cap.root_domain)
                 cap.update_app(app_name, redirectDomain=cap.root_domain)
 
     # Deploy GC Explorer if specified in config
@@ -290,9 +297,10 @@ def deploy_stack(config, gc_repository, dry_run):
                 automated=True,
                 one_click_repository=gc_repository,
             )
-            cap.enable_ssl(app_name)
+            if webapps_ssl:
+                cap.enable_ssl(app_name)
             cap.update_app(
-                app_name, force_ssl=True, redirectDomain=f"{app_name}.{cap.root_domain}"
+                app_name, force_ssl=webapps_ssl, redirectDomain=f"{app_name}.{cap.root_domain}"
             )
 
     # Deploy CoMapeo Cloud if specified in config
@@ -310,10 +318,11 @@ def deploy_stack(config, gc_repository, dry_run):
                 one_click_repository=gc_repository,
                 automated=True,
             )
-            cap.enable_ssl(app_name)
+            if webapps_ssl:
+                cap.enable_ssl(app_name)
             cap.update_app(
                 app_name,
-                force_ssl=True,
+                force_ssl=webapps_ssl,
                 support_websocket=True,
                 redirectDomain=f"{app_name}.{cap.root_domain}",
             )
@@ -332,9 +341,10 @@ def deploy_stack(config, gc_repository, dry_run):
                 app_variables=variables,
                 automated=True,
             )
-            cap.enable_ssl(app_name)
+            if webapps_ssl:
+                cap.enable_ssl(app_name)
             cap.update_app(
-                app_name, force_ssl=True, redirectDomain=f"{app_name}.{cap.root_domain}"
+                app_name, force_ssl=webapps_ssl, redirectDomain=f"{app_name}.{cap.root_domain}"
             )
 
             cap.update_app(


### PR DESCRIPTION
By submitting a pull request to this project, you agree to license your contribution under the terms of the MIT License.

Please read our [Contributor License Agreement and other Contributing Guidelines](CONTRIBUTING.md).

## Goal

https://github.com/ConservationMetrics/gc-deploy/pull/41 introduced an E2E test framework but it did not work to smoketest install webapps. This PR fixes two shortcomings and now the stack will install webapps:


## What I changed


1. `stack_deploy.py` had tried to enable/force SSL (HTTPS), which is not available on the local CapRover that the tests deployed. This PR adds an optional top-level config, `webappsUseSsl`. It defaults to True (keeps previous behavior) but can be overridden to `false` for the case of testing.
2. Our dependency [Caprover-API](https://github.com/ak4zh/Caprover-API/) doesn't support using local paths as one-click repo, you have to use `http` or `https` URLs.  This PR wraps the entire stack deploy with a context manager that serves a local `file://` URL on `http://localhost:####`.
