### PR TITLE
Fix postgres_ssl

### DIFF
--- a/caprover/gc-stack-deploy/src/gc_stack_deploy/stack_deploy.py
+++ b/caprover/gc-stack-deploy/src/gc_stack_deploy/stack_deploy.py
@@ -105,13 +105,13 @@ def deploy_stack(config, gc_repository, dry_run):
             )
         postgres_host = "srv-captain--postgres"
         postgres_port = "5432"
-        postgres_ssl = "false"
     else:
         # Using an external PostgreSQL instance
         logger.info("Using external PostgreSQL configuration.")
         postgres_host = config["postgres"]["host"]
         postgres_port = config["postgres"]["port"]
-        postgres_ssl = "true"
+    is_using_caprover_db = postgres_host.startswith("srv-captain--")
+    postgres_ssl = str(!is_using_caprover_db)  # as string "true" or "false"
 
     # Deploy Windmill if specified in config
     one_click_app_name = "windmill-only"
@@ -119,7 +119,7 @@ def deploy_stack(config, gc_repository, dry_run):
         app_name = config[one_click_app_name].get("app_name", one_click_app_name)
         windmill_db_user = config[one_click_app_name].pop("azure_db_user", config['postgres']['user'])
         windmill_db_pass = config[one_click_app_name].pop("azure_db_pass", config['postgres']['pass'])
-        is_using_caprover_db = postgres_host.startswith("srv-captain--")
+
         is_using_azure_db = (not is_using_caprover_db) and ("azure_db_user" in config[one_click_app_name])
         if is_using_azure_db:
             input("Before continuing, enable UUID-OSSP extension on the Azure database...")
@@ -221,7 +221,6 @@ def deploy_stack(config, gc_repository, dry_run):
     one_click_app_name = "superset-only"
     if config.get(one_click_app_name, {}).get("deploy", False):
         app_name = config[one_click_app_name].get("app_name", one_click_app_name)
-        is_using_caprover_db = postgres_host.startswith("srv-captain--")
         if is_using_caprover_db:
             run_psql_command_on_docker_service_container(
                 postgres_host,


### PR DESCRIPTION
By submitting a pull request to this project, you agree to license your contribution under the terms of the MIT License.

Please read our [Contributor License Agreement and other Contributing Guidelines](CONTRIBUTING.md).

## Goal
One edge case in gc-stack-deploy is if I set `postgres: deploy: false`, but DO try to deploy an app such as gc-explorer (because there was an error in the first run-through), then SSL will be set to true.

This fixes that.

## What I changed

We already sniff `postgres_host` for other reasons. This PR pushes that earlier and determines `postgres_ssl` from that.

Yes, we are assuming that on-caprover-VM postgres don't use SSL, but all external servers will. That assumption was present in the previous iteration and has not changed.

