### PR TITLE
CREATE DATABASE warehouse

### DIFF
--- a/caprover/gc-stack-deploy/src/gc_stack_deploy/stack_deploy.py
+++ b/caprover/gc-stack-deploy/src/gc_stack_deploy/stack_deploy.py
@@ -182,7 +182,10 @@ def deploy_stack(config, gc_repository, dry_run):
         ) as conn,
         conn.cursor() as cur,
     ):
-        cur.execute("CREATE DATABASE warehouse;")
+        try:
+            cur.execute("CREATE DATABASE warehouse;")
+        except psycopg.errors.DuplicateDatabase:
+            pass
 
     # Deploy Windmill if specified in config
     one_click_app_name = "windmill-only"


### PR DESCRIPTION
## Goal

Automate `CREATE DATABASE warehouse` as suggested in https://github.com/ConservationMetrics/gc-deploy/pull/49#issuecomment-3292976374

## What I changed

 #55 made it easy to run one-off SQL commands from the stack_deploy script, no matter whether the postgres server is hosted on the same VM in caprover, or external. This PR leverages that ability to run a simple `CREATE DATABASE warehouse`.

Since the script will ALWAYS run this,
- after it's run we'll always be sure that the database server is up and listening. Therefore I could remove `postgres_patient_connect` (retry logic) further down the script.
- the `CREATE DATABASE` handles the scenario where the database already existed (`try/except DuplicateDatabase`). Note that Postgresql doesn't have `CREATE DATABASE IF NOT EXISTS`.

