### PR TITLE
Info on troubleshooting disk space / log usage

### DIFF
--- a/azure/cloud-config.yml
+++ b/azure/cloud-config.yml
@@ -60,3 +60,9 @@ write_files:
       MOUNT_PATH=/mnt/persistent-storage
       mkdir -p "$MOUNT_PATH"
       mount -t cifs //', parameters('storageAccountName'), '.file.core.windows.net/', parameters('storageAccountFolder'), ' "$MOUNT_PATH" -o "vers=3.0,username=', parameters('storageAccountName'), ',password=', listKeys(resourceId('Microsoft.Storage/storageAccounts', parameters('storageAccountName')), '2022-09-01').keys[0].value, ',dir_mode=0777,file_mode=0777,serverino" || true
+  - path: /etc/systemd/journald.conf.d/diskspace.conf
+    permissions: "0644"
+    content: |
+      [Journal]
+      SystemMaxUse=900M
+      MaxRetentionSec=30day

--- a/caprover/TROUBLESHOOTING.md
+++ b/caprover/TROUBLESHOOTING.md
@@ -50,7 +50,7 @@ The most common culprits are:
 If those don’t fix it, you can explore disk usage by folder hierarchy:
 
     $ sudo apt install ncdu
-    $ ncdu
+    $ ncdu /
 
 
 ## Missing Volume Mount on VM

--- a/caprover/TROUBLESHOOTING.md
+++ b/caprover/TROUBLESHOOTING.md
@@ -31,8 +31,13 @@ Filesystem 	1K-blocks 	  Used Available Use% Mounted
 ```
 
 The most common culprits are:
-* Old, unused Docker images. To fix:
-    `$ sudo docker image prune`
+* Old, unused Docker images.
+    - Quick fix:
+        `$ sudo docker image prune`
+    - To prevent it from happening again, configure automatic daily disk cleanup at **CapRover > Maintenance > Disk Cleanup**
+* System logs can accumulate lots of data, check in particular disk usage of files under `/var/log/`.
+    - Make sure to configure `SystemMaxUse` in `/etc/systemd/journald.conf.d/diskspace.conf`. [Some of our new VM recipes already do this.](/azure/README.md)
+    - Check that all CapRover apps are healthy & stable. If an app is crashing upon startup and in a reboot loop, then CapRover will reconfigure nginx on each crash and each restart, and that operation will push a lot of log lines related to `docker-overlay2` and/or `networkd-dispatcher` and/or Docker network virtual devices "unregistering".
 * One of our Docker services writing lots to one of its Docker volumes. To find which volume:
     ```
     $ du --max-depth=1 /var/lib/docker/volumes/
@@ -42,9 +47,10 @@ The most common culprits are:
     $ find . -type f -mtime +14 -delete
     ```
 
-If those don’t fix it, you can scan how much disk is used by each root-level folder (this takes tens of minutes to run):
+If those don’t fix it, you can explore disk usage by folder hierarchy:
 
-    $ du --exclude=/mnt -h --max-depth=2 / | sort -h
+    $ sudo apt install ncdu
+    $ ncdu
 
 
 ## Missing Volume Mount on VM


### PR DESCRIPTION
By submitting a pull request to this project, you agree to license your contribution under the terms of the MIT License.

Please read our [Contributor License Agreement and other Contributing Guidelines](CONTRIBUTING.md).

## Goal

Document learnings to help troubleshoot disk space due to excessive log usage


Closes https://github.com/ConservationMetrics/gc-programs/issues/98


## What I changed

1. Return journald configuration on new Azure VMs.  This used to be in gc-forge, I don't know how it got lost (other than very likely being my fault)
2. Document `ncdu` tool to get a disk usage report
3. Document Caprover app restart loop flooding logs.
4. Document that you can configure CapRover to do docker image cleanup.

## What I'm not doing here

