### PR TITLE
Bugfix: gc-stack-deploy connects to just-deployed postgres by IP address

### DIFF
--- a/caprover/gc-stack-deploy/src/gc_stack_deploy/stack_deploy.py
+++ b/caprover/gc-stack-deploy/src/gc_stack_deploy/stack_deploy.py
@@ -159,7 +159,7 @@ def deploy_stack(config, gc_repository, dry_run):
 
         # this is the connection to be used from this script (which runs on the host)
         postgres_from_vm = PostgresConnectionConfig(
-            cap.root_domain,
+            "127.0.0.1",
             config["postgres"]["user"],
             config["postgres"]["pass"],
             ssl=False,


### PR DESCRIPTION
By submitting a pull request to this project, you agree to license your contribution under the terms of the MIT License.

Please read our [Contributor License Agreement and other Contributing Guidelines](CONTRIBUTING.md).

## Goal

This fixes problems when `cap.root_domain` had the DB port blocked by a firewall.

Now the `gc-stack-deploy` script (running on the host VM) can connect to the postgres server it just deployed even when a firewall blocks that port to the outside world. 


## What I changed
It gets around the firewall by using a localhost IP address.

This did not get caught by E2E tests because the E2E `stack.test.yaml` also uses a local domain in /etc/hosts defined as 127.0.0.1, so never left the box.

