### PR TITLE
New VMs launch on B2s_v2 (Bs will be discontinued)

### DIFF
--- a/azure/new-vm.arm.json
+++ b/azure/new-vm.arm.json
@@ -34,7 +34,7 @@
       }
     },
     "vmSize": {
-      "defaultValue": "Standard_B2s",
+      "defaultValue": "Standard_B2s_v2",
       "type": "String",
       "metadata": {
         "description": "Size of the virtual machine."


### PR DESCRIPTION
## Goal
New VMs launch on B2s_v2 (`B2s` will be discontinued in 2028)

https://learn.microsoft.com/en-us/azure/virtual-machines/migration/sizes/d-ds-dv2-dsv2-ls-series-migration-guide

## LLM use disclosure
None