### PR TITLE
Install new CaproverAPI patches

### DIFF
--- a/caprover/gc-stack-deploy/pyproject.toml
+++ b/caprover/gc-stack-deploy/pyproject.toml
@@ -5,7 +5,7 @@ description = "Deploy Guardian Connector stack of apps to the (locally running) 
 requires-python = ">=3.9"
 dependencies = [
     "psycopg[binary]",
-    "Caprover-API @ git+https://github.com/IamJeffG/Caprover-API.git@fix-oneclick-repo",
+    "Caprover-API @ git+https://github.com/IamJeffG/Caprover-API.git@all-patches-2025-nov",
 ]
 
 [project.urls]


### PR DESCRIPTION
## Goal
Fixes #25 

The main change here is CaproverAPI now detects "429 Too Many Requests" state from the server and retry for up to 90 seconds. I'm not sure that will be long enough to cover _all cases_ where we see #25 but we have to start somewhere.

## What I changed

Install a fork of CaproverAPI that includes these (as yet) unmerged fixes:

- https://github.com/ak4zh/Caprover-API/pull/23
- https://github.com/ak4zh/Caprover-API/pull/24


## LLM use disclosure
None