### PR TITLE
Add step for enabling auto-backups to post deployment checklist

### DIFF
--- a/POST-DEPLOYMENT-CHECKLIST.md
+++ b/POST-DEPLOYMENT-CHECKLIST.md
@@ -7,6 +7,7 @@ It covers the manual steps that are not already automated through the scripts an
 
 - [ ] Did I set the A records in my DNS provider? (And can confirm it resolves to the VM's IP?)
 - [ ] Did I add SSH keys to `~/.ssh/authorized_keys` for everyone who needs access to the VM?
+- [ ] Did I enable auto-backups for the VM and/or the data warehouse?
 
 ## CapRover and services
 


### PR DESCRIPTION
## Goal

To document the need to enable automatic backups for the VM and/or data warehouse

Responding to https://github.com/ConservationMetrics/gc-forge/issues/81

## Screenshots


## What I changed and why


## What I'm not doing here


## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->
