### PR TITLE
Update auth0 RBAC docs Inline with new UI update

### DIFF
--- a/auth0/README.md
+++ b/auth0/README.md
@@ -78,8 +78,8 @@ Role-Based Access Control (RBAC) allows you to control user access to different 
 ### API Configuration
 
 1. Go to **Dashboard > Applications > APIs** and find the "Auth0 Management API" API
-2. For that API, go to the **"Machine to Machine Applications"** tab
-3. Find your application in the list and **Authorize** it
+2. For that API, go to the **"Application Access"** tab
+3. Find your application in the list and click edit navigating to **Client Credentials** tab.
 4. For each application, select the required scopes:
    - **GC-Explorer** (read-only access):
      - `read:users` - to fetch user information


### PR DESCRIPTION

## Goal
While setting up RBAC for NPDC i realised Auth0 RBAC has changed, it no longer uses machine-to-machine and now just consolidates under one tab. 

## Screenshots
<img width="315" height="79" alt="Screenshot 2026-01-22 at 17 19 31" src="https://github.com/user-attachments/assets/d84858d0-0deb-48c5-9b59-66b28e89b22e" />
<img width="264" height="92" alt="Screenshot 2026-01-22 at 17 13 30" src="https://github.com/user-attachments/assets/97ef1f83-fb5f-4fb1-94de-02f733a0f4e2" />

## What I changed and why
Updated section to have proper relevant information, no more machine-to-machine.



## What I'm not doing here


## LLM use disclosure
None
