### PR TITLE
Clarify need to set retention period for Windmill instance

### DIFF
--- a/caprover/INSTALL_GC_STACK.md
+++ b/caprover/INSTALL_GC_STACK.md
@@ -188,7 +188,10 @@ No additional steps needed.
 
 Instance Settings Page
 
-* **Core** tab > Default timeout = 30 Min
+* **Core** tab
+  
+  * Default timeout = 30 Min
+  * Retention period in secs= 2592000 (30 Days)
 
 * **Telemetry** tab > Disable telemetry
 


### PR DESCRIPTION
## Goal

It has been observed on at least one instance that job retention was set to 1800 seconds (30 minutes). This is undesirable. This change documents the need to check that we are retaining jobs / runs for the maximum time allowed within non-enterprise usage.