### PR TITLE
Document service upgrades, including CapRover

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,5 @@ High-level steps to spawn a new stack
     - See [**ConservationMetrics/gc-scripts-hub**](https://github.com/ConservationMetrics/gc-scripts-hub/)
 
 6. 🔍 Use the [Post-Deployment Checklist](POST-DEPLOYMENT-CHECKLIST.md) to validate your deployment.
+
+7. 🔧 Once all is deployed, use the [Service Upgrades](caprover/SERVICE_UPGRADES.md) guide to regularly upgrade the services to the latest versions.

--- a/caprover/INSTALL_GC_STACK.md
+++ b/caprover/INSTALL_GC_STACK.md
@@ -261,15 +261,7 @@ See [`./one-click-apps/README.md`](./one-click-apps/README.md) for full example.
 
 ## Upgrade Apps
 
-Most apps allow you to simply update the underlying image from the CapRover webapp
-using [**Method 6: Deploy via ImageName**](https://caprover.com/docs/one-click-apps.html#simple-image-update).  You can confirm this applies to you in CapRover under
-**Deployment > Version History**. If the latest "Image Name" is the official image,
-you can use Method 6 and paste the new official image.
-
-But if the latest "Image Name" is something like `img-captain-...` then you may need
-to use one of the other methods. See the app's documentation.
-
-If an app comprises multiple services you will need to Deploy the new image on each one.
+Please see the [Service Upgrades](SERVICE_UPGRADES.md) guide for instructions on how to upgrade the apps.
 
 ## Manually installing apps
 

--- a/caprover/README.md
+++ b/caprover/README.md
@@ -2,8 +2,12 @@
 
 ## Installation Guides
 
-1. [Install CapRover on New VM](INSTALL_CAPROVER_ON_NEW_VM.md)
-2. [Install Guardian Connector Stack](INSTALL_GC_STACK.md)
+* [Install CapRover on New VM](INSTALL_CAPROVER_ON_NEW_VM.md)
+* [Install Guardian Connector Stack](INSTALL_GC_STACK.md)
+
+## Maintenance and Upgrades
+
+* [Service Upgrades](SERVICE_UPGRADES.md)
 
 ## Developers Reference
 

--- a/caprover/SERVICE_UPGRADES.md
+++ b/caprover/SERVICE_UPGRADES.md
@@ -1,0 +1,44 @@
+# Service Upgrades
+
+This document describes how to upgrade components in the Guardian Connector stack.
+
+There are two distinct upgrade paths, depending on what you are changing:
+
+1. **CapRover upgrades** – upgrading the CapRover server itself  
+2. **Service upgrades** – upgrading one or more deployed application images
+
+Service upgrades can be performed in two alternative ways, depending on scale and workflow:
+
+- **Option A:** Manual image upgrades via the CapRover UI  
+- **Option B:** Batch upgrades to a service across many Guardian Connectorinstances using the `caprover-batch-deploy` tool
+
+Use the sections below to jump directly to the relevant procedure.
+
+## Upgrading CapRover
+
+The CapRover UI indicates when there is a new version of CapRover available. You will see a "🎁 🎁 Update Available 🎁 🎁!" message at the top of the dashboard. Clicking on it will take to you to a `/maintenance` page, where you can click on the "Install Update" button to install the latest update.
+
+However, as noted on that page:
+
+> CapRover allows in-place updates to be installed. However, always read the change logs before updating your CapRover. There might be breaking changes that you need to be aware of. The update usually takes around 60 seconds and your CapRover may become unresponsive until the update process is finished. Your apps will stay functional and responsive during this time, except for a very short period of 10 seconds or less.
+
+CapRover updates can take a few minutes, and you might see service downtime or nginx errors during and shortly after the update.
+
+
+## Manual image upgrades via CapRover UI
+
+Most apps allow you to simply update the underlying image from the CapRover webapp using [**Method 6: Deploy via ImageName**](https://caprover.com/docs/one-click-apps.html#simple-image-update). You can confirm this applies to you in CapRover under **Deployment > Version History**. If the latest "Image Name" is the official image, you can use Method 6 and paste the new official image.
+
+But if the latest "Image Name" is something like `img-captain-...` then you may need to use one of the other methods. See the app's documentation.
+
+If an app comprises multiple services (for example, Superset and Windmill) you will need to Deploy the new image on each one.
+
+## Using the `caprover-batch-deploy` tool
+
+CMI has developed a tool that can batch upgrade Guardian Connector services to multiple CapRover instances via the HTTP API. The script authenticates with CapRover API using passwords read from a KeePass database.
+
+We keep this tool in a private repository as it is built to work with our own KeePass database and credential storage patterns, but it is available on request. Please reach out to us if you would like to use it.
+
+## Upgrade patterns
+
+For CMI's own deployments, we aim to keep the Guardian Connector stack up to date with the latest versions of the underlying services. We aim to upgrade the stack once a month, on the last Tuesday of the month.


### PR DESCRIPTION
## Goal

Together with https://github.com/ConservationMetrics/gc-programs/pull/137, closes https://github.com/ConservationMetrics/gc-forge/issues/62.

## What I changed and why

* Created a service upgrades guide
* Moved existing manual upgrade documentation to there.
* Added reference to the batch deploy script
* Added documentation for upgrading CapRover

## What I'm not doing here


## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

None