### PR TITLE
Use consistent patterns for image tags in one-click-app definitions

### DIFF
--- a/caprover/SERVICE_UPGRADES.md
+++ b/caprover/SERVICE_UPGRADES.md
@@ -33,7 +33,7 @@ But if the latest "Image Name" is something like `img-captain-...` then you may 
 
 If an app comprises multiple services (for example, Superset and Windmill) you will need to Deploy the new image on each one.
 
-## Using the `caprover-batch-deploy` tool
+## Using the `caprover_batch_deploy` tool
 
 CMI has developed a tool that can batch upgrade Guardian Connector services to multiple CapRover instances via the HTTP API. The script authenticates with CapRover API using passwords read from a KeePass database.
 

--- a/caprover/one-click-apps/README.md
+++ b/caprover/one-click-apps/README.md
@@ -24,6 +24,14 @@ Our CapRover one-click app definitions are built and published automatically via
 
 If you are writing your own one-click-apps, follow these suggestions.
 
+### Use full image name for Docker image variables
+
+When you are defining a Docker image variable in a one-click-app and setting a default value, use the full image name, including the repository and tag.
+
+For example, if the image is `ghcr.io/windmill-labs/windmill:1.648.0`, set that as your `defaultValue` instead of just `1.648.0`.
+
+The reason is that CMI's [`caprover_batch_deploy`](../SERVICE_UPGRADES.md#using-the-caprover_batch_deploy-tool) tool will use the full image name to update the one-click-app definition in the `gc-deploy` repository.
+
 ### Use "Service Update Override" to change how the Docker Image behaves
 
 There are times you need to change some of the configuration inside the upstream Docker image.

--- a/caprover/one-click-apps/README.md
+++ b/caprover/one-click-apps/README.md
@@ -26,7 +26,7 @@ If you are writing your own one-click-apps, follow these suggestions.
 
 ### Use full image name for Docker image variables
 
-When you are defining a Docker image variable in a one-click-app and setting a default value, use the full image name, including the repository and tag.
+When you are defining a Docker image variable in a one-click-app and setting a default value, use the full image name, including the repository and tag e.g.`<HOST>/<NAMESPACE>/<REPOSITORY>:TAG`.
 
 For example, if the image is `ghcr.io/windmill-labs/windmill:1.648.0`, set that as your `defaultValue` instead of just `1.648.0`.
 

--- a/caprover/one-click-apps/v4/apps/windmill-only.yml
+++ b/caprover/one-click-apps/v4/apps/windmill-only.yml
@@ -2,7 +2,7 @@ captainVersion: 4
 
 services:
   $$cap_appname:
-    image: ghcr.io/windmill-labs/windmill:$$cap_app_version
+    image: $$cap_app_docker_image
     expose:
       - 8000
     environment:
@@ -15,7 +15,7 @@ services:
       containerHttpPort: 8000
 
   $$cap_appname-worker:
-    image: ghcr.io/windmill-labs/windmill:$$cap_app_version
+    image: $$cap_app_docker_image
     volumes:
       # mount the docker socket to allow to run docker containers from within the workers
       - /var/run/docker.sock:/var/run/docker.sock
@@ -31,7 +31,7 @@ services:
       notExposeAsWebApp: "true"
 
   $$cap_appname-worker-native:
-    image: ghcr.io/windmill-labs/windmill:$$cap_app_version
+    image: $$cap_app_docker_image
     volumes:
       - $$cap_appname-worker-logs:/tmp/windmill/logs
       - /mnt/persistent-storage:/persistent-storage
@@ -118,9 +118,9 @@ caproverOneClickApp:
   description: Windmill is developer infrastructure for internal tools. You will need to create and configure the database information manually. Intended for advanced users.
   documentation: https://www.windmill.dev/
   variables:
-    - id: $$cap_app_version
-      label: Windmill Version
-      defaultValue: "1.648.0"
+    - id: $$cap_app_docker_image
+      label: Windmill Docker Image
+      defaultValue: "ghcr.io/windmill-labs/windmill:1.648.0"
       description: Checkout their github page for the valid tags https://github.com/windmill-labs/windmill/releases
       validRegex: /^([^\s^\/])+$/
 


### PR DESCRIPTION
## Goal

Towards https://github.com/ConservationMetrics/gc-deploy/issues/86.

To set the expectation for the same `<HOST>/<NAMESPACE>/<REPOSITORY>:TAG` format for default values consistently across all one-click-app definitions, so we can more easily programmatically modify them e.g. in `caprover_batch_deploy`.

Windmill was the only odd one out, so I modified it.

I briefly considered whether we should just hard-code `<HOST>/<NAMESPACE>/<REPOSITORY>` and only let the CapRover user set the tag, but didn't feel strongly either way so decided to stick with the convention already used by 4/5 apps.

## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

None