### PR TITLE
Set memory limit on new app deployments

### DIFF
--- a/caprover/gc-stack-deploy/src/gc_stack_deploy/stack_deploy.py
+++ b/caprover/gc-stack-deploy/src/gc_stack_deploy/stack_deploy.py
@@ -21,6 +21,7 @@ import threading
 import time
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass, replace
+from functools import reduce
 
 import psycopg
 import yaml
@@ -41,6 +42,44 @@ def load_config(file_path):
         print(f"Configuration file {file_path} not found.")
         sys.exit(1)
     return config
+
+
+def set_yaml_value(yaml_str: str, key: str | list[str], value: object) -> str:
+    """
+    Set a value at a (nested) key in a YAML string and return the updated YAML.
+
+    Parameters
+    ----------
+    yaml_str
+        YAML-formatted string.
+    key
+        Dot-delimited string (e.g. "a.b.c") or list of key segments.
+    value
+        Value to set.
+
+    Returns
+    -------
+    Re-serialized YAML string.
+    """
+    data = yaml.safe_load(yaml_str) or {}
+
+    keys = key.split(".") if isinstance(key, str) else key
+
+    # Walk to the parent, creating intermediate dicts as needed
+    parent = reduce(lambda d, k: d.setdefault(k, {}), keys[:-1], data)
+    parent[keys[-1]] = value
+
+    return yaml.dump(data, default_flow_style=False, allow_unicode=True)
+
+
+def set_memory_limit(cap, appname, memory_bytes=1610612736):
+    app = cap.get_app(appname)
+    new_suo = set_yaml_value(
+        app["serviceUpdateOverride"],
+        "TaskTemplate.Resources.Limits.MemoryBytes",
+        memory_bytes,
+    )
+    cap.update_app(appname, serviceUpdateOverride=new_suo)
 
 
 def construct_app_variables(config, service_name, init=None):
@@ -277,6 +316,13 @@ def deploy_stack(config, gc_repository, dry_run):
                 cap.enable_ssl(app_name)
                 cap.update_app(app_name, force_ssl=True)
 
+            for svcname in (
+                app_name,
+                f"{app_name}-worker",
+                f"{app_name}-worker-native",
+            ):
+                set_memory_limit(cap, svcname)
+
     # Deploy Redis if specified in config
     one_click_app_name = "redis"
     if config.get(one_click_app_name, {}).get("deploy", False):
@@ -290,6 +336,7 @@ def deploy_stack(config, gc_repository, dry_run):
                 app_variables=variables,
                 automated=True,
             )
+            set_memory_limit(cap, app_name)
 
     # Deploy Superset if specified in config
     one_click_app_name = "superset-only"
@@ -330,11 +377,18 @@ def deploy_stack(config, gc_repository, dry_run):
             # does this in a custom dockerfileLines, but recommended to ease upgrades.
             for appname in (f"{app_name}-init-and-beat", f"{app_name}-worker"):
                 worker_app = cap.get_app(appname)
-                new_suo = (
-                    worker_app["serviceUpdateOverride"]
-                    + '\n    HealthCheck:\n      Test: ["NONE"]'
+                new_suo = set_yaml_value(
+                    worker_app["serviceUpdateOverride"],
+                    "TaskTemplate.HealthCheck.Test",
+                    ["NONE"],
+                )
+                # Also set memory limit to workers
+                new_suo = set_yaml_value(
+                    new_suo, "TaskTemplate.Resources.Limits.MemoryBytes", 1610612736
                 )
                 cap.update_app(appname, serviceUpdateOverride=new_suo)
+
+            set_memory_limit(cap, app_name)  # The web service (not worker)
 
     # Deploy GC Landing Page if specified in config
     # Note: as GC Landing Page is intended to be the default landing page, we don't need to add a redirect domain, and instead, we set the redirectDomain to the root domain. (e.g. so that the landing page will load when a user accesses "your-captain-root.net")
@@ -355,6 +409,7 @@ def deploy_stack(config, gc_repository, dry_run):
             if webapps_ssl:
                 cap.enable_ssl(app_name)
                 cap.update_app(app_name, force_ssl=True)
+            set_memory_limit(cap, app_name)
 
         if redirect_to_root:
             logger.info(
@@ -402,6 +457,7 @@ def deploy_stack(config, gc_repository, dry_run):
                 force_ssl=webapps_ssl,
                 redirectDomain=f"{app_name}.{cap.root_domain}",
             )
+            set_memory_limit(cap, app_name)
 
     # Deploy CoMapeo Cloud if specified in config
     one_click_app_name = "comapeo-cloud"
@@ -426,6 +482,7 @@ def deploy_stack(config, gc_repository, dry_run):
                 support_websocket=True,
                 redirectDomain=f"{app_name}.{cap.root_domain}",
             )
+            set_memory_limit(cap, app_name)
 
     # Deploy Filebrowser if specified in config
     one_click_app_name = "filebrowser"
@@ -460,6 +517,7 @@ def deploy_stack(config, gc_repository, dry_run):
                 # https://github.com/ConservationMetrics/gc-deploy/pull/12#discussion_r2243697895
                 environment_variables={"FB_ROOT": "/srv/datalake"},
             )
+            set_memory_limit(cap, app_name)
 
 
 def is_local_path(path):

--- a/caprover/one-click-apps/v4/apps/windmill-only.yml
+++ b/caprover/one-click-apps/v4/apps/windmill-only.yml
@@ -122,7 +122,6 @@ caproverOneClickApp:
       label: Windmill Docker Image
       defaultValue: "ghcr.io/windmill-labs/windmill:1.648.0"
       description: Checkout their github page for the valid tags https://github.com/windmill-labs/windmill/releases
-      validRegex: /^([^\s^\/])+$/
 
     - id: $$cap_database_url
       label: Database URL


### PR DESCRIPTION
## Goal

Set memory limit on new app deployments

Toward #100


## What I changed and why

Fixes a bug in the windmill-only one-click-app introduced in #91 

Set memory limit on new app deployments.
- After each app installed, when `not dry_run`, it gets the latest app definition's serviceUpdateOverride, merges the `Resources.MemoryBytes` limit into it, and calls `CaproverAPI.update_app` with the new value.
- It does this for both workers and web services.

It's a bit of DRY violation but this script is full of them and I haven't found a satisfactory way to DRY it since every app is a little different.

## Why I believe it works
- I confirmed it works by running the [E2E test harness](https://github.com/ConservationMetrics/gc-deploy/tree/main/caprover/tests), and then opening the new apps in CapRover and confirmed the memory limit was set on them.

> <img width="280" height="176" alt="image" src="https://github.com/user-attachments/assets/37d2ba0e-7c44-4237-8cb3-7d90c283ca5f" />

It also correctly merges our Resource constraint with existing `Command` in the Service Update Override -- here's the redis app:
  ```yaml
  TaskTemplate:
    ContainerSpec:
      Command:
      - sh
      - -c
      - redis-server --requirepass $REDIS_PASSWORD
    Resources:
      Limits:
        MemoryBytes: 1610612736
  ```

## What I'm not doing here

Setting memory limit on existing deployments will be done separately.


## LLM use disclosure

Claude Sonnet wrote the function `set_yaml_value`. I did the rest.