### PR TITLE
Add LOCAL-DEVELOPMENT.md 

### DIFF
--- a/caprover/LOCAL-DEVELOPMENT.md
+++ b/caprover/LOCAL-DEVELOPMENT.md
@@ -1,0 +1,52 @@
+# Set up CapRover locally for development
+
+To set up CapRover locally, see this guide: https://caprover.com/docs/run-locally.html
+
+If the local installation incantation in the guide doesn't work for you, or if you prefer to handle local development setup in an isolated virtual environment, you can take the approach suggested in [this video tutorial](https://www.youtube.com/watch?v=J_6H11DrzXY) of spinning up a Docker inside of Docker (`dind`) image:
+
+1. Set up the `dind` image:
+
+    ```bash
+    docker run --privileged -d -p 80:80 -p 443:443 -p 3000:3000 --name caprover-docker docker:dind
+    ```
+
+2. Open an interactive shell session inside the `caprover-docker` container:
+
+    ```bash
+    docker exec -it caprover-docker /bin/sh
+    ```
+
+3. Create the `/captain/data` directory:
+
+    ```bash
+    mkdir -p /captain/data/
+    ```
+
+4. Now, you can run the installation command for local installation from the guide:
+
+    ```bash
+    echo  "{\"skipVerifyingDomains\":\"true\"}" >  /captain/data/config-override.json
+    docker run -e ACCEPTED_TERMS=true \
+    -e MAIN_NODE_IP_ADDRESS=127.0.0.1 \
+    -p 80:80 -p 443:443 -p 3000:3000 \
+    -v /var/run/docker.sock:/var/run/docker.sock \
+    -v /captain:/captain caprover/caprover
+    ```
+
+5. If you want to check on the initialization status, you can run
+   ```bash
+   docker ps
+   ```
+
+   Find the container id, and then run
+
+   ```bash
+   docker logs -f <container_id>
+   ```
+
+   If successfully initiatized, you should see a log message:
+   ```
+   **** Captain is initialized and ready to serve you! ****
+   ```
+
+6. Now, you can access CapRover at http://captain.captain.localhost:3000/ (or a different port if you opted for one in step 4). The password for the initial setup is `captain42`.

--- a/caprover/README.md
+++ b/caprover/README.md
@@ -4,6 +4,7 @@
 
 * [Install CapRover on New VM](INSTALL_CAPROVER_ON_NEW_VM.md)
 * [Install Guardian Connector Stack](INSTALL_GC_STACK.md)
+* [Set up CapRover locally for development](LOCAL-DEVELOPMENT.md)
 
 ## Maintenance and Upgrades
 


### PR DESCRIPTION
## Goal

To add `LOCAL-DEVELOPMENT.md` as a final leftover to open-source from our private deployment repo.

Honestly, I can't say if this README is valuable to offer, as opposed to CapRover's own instructions for local deployment. But that isn't what I'm focusing on here, so I thought to file this draft PR for now, to complete the repo boundary work that I sought out to do.

## LLM use disclosure
<!--
    Briefly describe any significant use of LLMs in this PR, e.g., for consultation, code generation, documentation, or PR body.
    If none, state "None".
    Trivial tab-completion doesn't need to be disclosed.
-->

None