### PR TITLE
Align Cap Auth0 client id keys and root-domain base URL for landing page

### DIFF
--- a/caprover/gc-stack-deploy/src/gc_stack_deploy/example_configs/stack.example.yaml
+++ b/caprover/gc-stack-deploy/src/gc_stack_deploy/example_configs/stack.example.yaml
@@ -41,7 +41,7 @@ superset-only:
   redis_key_prefix: "eg_"
   ### OPTIONAL, but you probably want to override:
   auth0_domain: 
-  auth0_clientid: 
+  auth0_client_id: 
   auth0_client_secret: 
   admin_email: "admin@guardianconnector.net"  # IMPORTANT: this should be changed to the email address of the first admin user who will log in with auth0
   mapbox_api_key:  # If you want to use Mapbox for maps; can also be set later
@@ -58,7 +58,7 @@ gc-landing-page:
   ### REQUIRED: 
   community_name:  # IMPORTANT: this is the URL slug of the community, e.g. "springfield" in "springfield.your-captain-root.net". It must not contain any special characters or spaces.
   auth0_domain: 
-  auth0_clientid: 
+  auth0_client_id: 
   auth0_client_secret: 
   ### OPTIONAL, but you probably want to override. Should be set according to services available in the community (e.g. if you don't have Superset, set `superset_enabled: false`)
   superset_enabled: 
@@ -73,7 +73,7 @@ gc-explorer:
   ### REQUIRED:
   postgres_database: "warehouse"
   auth0_domain: 
-  auth0_clientid: 
+  auth0_client_id: 
   auth0_client_secret: 
 
 comapeo-cloud:

--- a/caprover/one-click-apps/v4/apps/gc-explorer.yml
+++ b/caprover/one-click-apps/v4/apps/gc-explorer.yml
@@ -17,7 +17,7 @@ services:
 
       NUXT_PUBLIC_AUTH_STRATEGY: $$cap_auth_strategy
       NUXT_OAUTH_AUTH0_DOMAIN: $$cap_auth0_domain
-      NUXT_OAUTH_AUTH0_CLIENT_ID: $$cap_auth0_clientid
+      NUXT_OAUTH_AUTH0_CLIENT_ID: $$cap_auth0_client_id
       NUXT_OAUTH_AUTH0_CLIENT_SECRET: $$cap_auth0_client_secret
 
       NUXT_PUBLIC_APP_API_KEY: $$cap_public_app_api_key
@@ -63,7 +63,7 @@ caproverOneClickApp:
     - id: "$$cap_auth0_domain"
       label: Auth0 Domain
       description: optional, to login using Auth0
-    - id: "$$cap_auth0_clientid"
+    - id: "$$cap_auth0_client_id"
       label: Auth0 Client ID
       description: optional, to login using Auth0
     - id: "$$cap_auth0_client_secret"

--- a/caprover/one-click-apps/v4/apps/gc-landing-page.yml
+++ b/caprover/one-click-apps/v4/apps/gc-landing-page.yml
@@ -15,7 +15,7 @@ services:
       NUXT_PUBLIC_FILEBROWSER_ENABLED: $$cap_filebrowser_enabled
       NUXT_PUBLIC_WINDMILL_ENABLED: $$cap_windmill_enabled
       NUXT_PUBLIC_EXPLORER_ENABLED: $$cap_explorer_enabled
-      NUXT_PUBLIC_BASE_URL: https://$$cap_appname.$$cap_root_domain
+      NUXT_PUBLIC_BASE_URL: https://$$cap_root_domain
       NUXT_PUBLIC_DOMAIN: $$cap_root_domain
       NUXT_PUBLIC_LOGO_URL: $$cap_logo_url
       NUXT_SESSION_PASSWORD: $$cap_session_password

--- a/caprover/one-click-apps/v4/apps/superset-only.yml
+++ b/caprover/one-click-apps/v4/apps/superset-only.yml
@@ -13,7 +13,7 @@ services:
       CACHE_KEY_PREFIX: $$cap_redis_key_prefix
       DATABASE_URI: postgresql://$$cap_postgres_userpassword@$$cap_postgres_host:$$cap_postgres_port/superset_metastore
       AUTH0_DOMAIN: $$cap_auth0_domain
-      AUTH0_CLIENTID: $$cap_auth0_clientid
+      AUTH0_CLIENTID: $$cap_auth0_client_id
       AUTH0_CLIENT_SECRET: $$cap_auth0_client_secret
       MAPBOX_API_KEY: $$cap_mapbox_api_key
       APP_ICON: $$cap_app_icon
@@ -101,7 +101,7 @@ caproverOneClickApp:
     - id: "$$cap_auth0_domain"
       label: Auth0 Domain
       description: optional, to login using Auth0
-    - id: "$$cap_auth0_clientid"
+    - id: "$$cap_auth0_client_id"
       label: Auth0 Client ID
       description: optional, to login using Auth0
     - id: "$$cap_auth0_client_secret"


### PR DESCRIPTION
## Goal

Align Guardian Connector deploy definitions and the stack example config with how the landing page is served at the community root domain, and remove the `clientid` vs `client_id` mismatch between `gc-stack-deploy`’s injected `$$cap_*` keys and the `gc-landing-page` one-click app.

## Screenshots

N/A

## What I changed and why

- Fixed `NUXT_PUBLIC_BASE_URL` to use `https://$$cap_root_domain` instead of `https://$$cap_appname.$$cap_root_domain` since the landing page is mapped to the apex domain
- Resolved a `$$cap_auth0_clientid` vs `$$cap_auth0_client_id` mismatch, the example stack file, Explorer, and Superset one-click apps now all use `auth0_client_id` / `$$cap_auth0_client_id` consistently with `auth0_client_secret`

## What I'm not doing here


## LLM use disclosure

None