### PR TITLE
[gc-stack-deploy] Fix confusion and bugs around local-hosted postgres

### DIFF
--- a/caprover/INSTALL_GC_STACK.md
+++ b/caprover/INSTALL_GC_STACK.md
@@ -77,7 +77,7 @@ If the script ran successfully, you can proceed to the [Post-install app configu
 
 > [!TIP]
 > If something goes wrong in the middle of the `gc-stack-deploy` script, you have several options:
-> - You can delete the app from CapRover and redeploy it using the `gc-stack-deploy` script. For any applications that were installed successfully, you can set `deploy: false` in the `stack.yaml` file to skip them in the next run. In doing so, please pay careful attention to any app-specific instructions (i.e., providing a host and port for Postgres).
+> - You can delete the app from CapRover and redeploy it using the `gc-stack-deploy` script. For any applications that were installed successfully, you can set `deploy: false` in the `stack.yaml` file to skip them in the next run.
 > - You can manually install the apps using the one-click app install menu. See [Manually installing apps section](#manually-installing-apps) for more details.
 
 #### What could go wrong?

--- a/caprover/gc-stack-deploy/pyproject.toml
+++ b/caprover/gc-stack-deploy/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "gc-stack-deploy"
-version = "0.1.0"
+version = "0.2.0"
 description = "Deploy Guardian Connector stack of apps to the (locally running) Caprover instance."
 requires-python = ">=3.9"
 dependencies = [

--- a/caprover/gc-stack-deploy/src/gc_stack_deploy/example_configs/stack.example.yaml
+++ b/caprover/gc-stack-deploy/src/gc_stack_deploy/example_configs/stack.example.yaml
@@ -1,23 +1,32 @@
 # TODO: make it easier to populate this file, e.g. not needing to put in auth0 domain multiple times.
 
 caproverUrl: "http[s]://captain.your-captain-root.net"  # Remove the brackets if using SSL, remove `[s]` if using HTTP.
-caproverPassword: "secret-captain-password"  # Set a secure password! 
+caproverPassword: "secret-captain-password"  # Set a secure password!
 
 postgres:
-  deploy: true  # Set to false to skip PostgreSQL deployment, then uncomment the next lines.
-
-  # Set only when deploy: false
-  # host: "srv-captain--postgres"
-  # port: 5432
+  deploy: true  # Set to false to skip PostgreSQL deployment (including on a resume run).
 
   # REQUIRED in all cases:
   user: "postgres"  # Do not change this
   pass: "your_pg_password"  # Set a secure password
-
-  # Set only when deploy: true
   database: postgres  # `warehouse` will be created in the stack deploy script
   version: 17
-  expose_port: 15432  # the container will map to this port on the host VM
+
+  # How this script (running on the VM) reaches Postgres.
+  # For CapRover-internal Postgres:
+  #   host is 127.0.0.1
+  #   When `deploy: false`, leave it exactly the same as it was on the first run.
+  # For external Postgres, this will be the same as `from_container` below.
+  from_vm:
+    host: 127.0.0.1
+    port: 15432   # when deploy:true, the container will map to this port on the host VM
+
+  # How other CapRover apps reach Postgres (injected as env vars).
+  # For Postgres hosted on CapRover, this is the service name on the Docker network.
+  # For external Postgres, point this at the external host/port.
+  from_container:
+    host: srv-captain--postgres
+    port: 5432
 
 windmill-only:
   deploy: true

--- a/caprover/gc-stack-deploy/src/gc_stack_deploy/example_configs/stack.example.yaml
+++ b/caprover/gc-stack-deploy/src/gc_stack_deploy/example_configs/stack.example.yaml
@@ -11,20 +11,10 @@ postgres:
   pass: "your_pg_password"  # Set a new password, avoid special chars that apps may misparse in connection strings
   database: postgres  # `warehouse` will be created in the stack deploy script
   version: 17
-
-  # How this script (running on the VM) reaches Postgres.
-  # For CapRover-internal Postgres:
-  #   host is 127.0.0.1
-  #   When `deploy: false`, leave it exactly the same as it was on the first run.
-  # For external Postgres, this will be the same as `from_container` below.
   from_vm:
     host: 127.0.0.1
     port: 15432   # when deploy:true, the container will map to this port on the host VM
     ssl: false    # ignored when deploy:true (forced false). Set true for external Postgres requiring SSL.
-
-  # How other CapRover apps reach Postgres (injected as env vars).
-  # For Postgres hosted on CapRover, this is the service name on the Docker network.
-  # For external Postgres, point this at the external host/port.
   from_container:
     host: srv-captain--postgres
     port: 5432

--- a/caprover/gc-stack-deploy/src/gc_stack_deploy/example_configs/stack.example.yaml
+++ b/caprover/gc-stack-deploy/src/gc_stack_deploy/example_configs/stack.example.yaml
@@ -8,7 +8,7 @@ postgres:
 
   # REQUIRED in all cases:
   user: "postgres"  # Do not change this
-  pass: "your_pg_password"  # Set a secure password
+  pass: "your_pg_password"  # Set a new password, avoid special chars that apps may misparse in connection strings
   database: postgres  # `warehouse` will be created in the stack deploy script
   version: 17
 

--- a/caprover/gc-stack-deploy/src/gc_stack_deploy/example_configs/stack.example.yaml
+++ b/caprover/gc-stack-deploy/src/gc_stack_deploy/example_configs/stack.example.yaml
@@ -20,6 +20,7 @@ postgres:
   from_vm:
     host: 127.0.0.1
     port: 15432   # when deploy:true, the container will map to this port on the host VM
+    ssl: false    # ignored when deploy:true (forced false). Set true for external Postgres requiring SSL.
 
   # How other CapRover apps reach Postgres (injected as env vars).
   # For Postgres hosted on CapRover, this is the service name on the Docker network.
@@ -27,6 +28,7 @@ postgres:
   from_container:
     host: srv-captain--postgres
     port: 5432
+    ssl: false    # ignored when deploy:true (forced false). Set true for external Postgres requiring SSL.
 
 windmill-only:
   deploy: true

--- a/caprover/gc-stack-deploy/src/gc_stack_deploy/stack_deploy.py
+++ b/caprover/gc-stack-deploy/src/gc_stack_deploy/stack_deploy.py
@@ -79,6 +79,42 @@ def set_yaml_value(yaml_str: str | None, key: str | list[str], value: object) ->
     return buf.getvalue()
 
 
+def _verify_existing_postgres_app(
+    cap, pg_app_name, postgres_from_container, postgres_from_vm
+):
+    """
+    If the pg_app_name app exists in CapRover, sanity-check that its configuration
+    (host and port) match what was parsed from YAML `from_container`/`from_vm`
+
+    Warn on mismatch. We don't fail (but maybe we should).
+    """
+    app = cap.get_app(pg_app_name)
+    if not app:
+        # No `postgres` app in CapRover — assume external Postgres.
+        return
+
+    if postgres_from_container.host != "srv-captain--postgres":
+        logger.warn(
+            f"===== A `{pg_app_name}` app exists in CapRover, but from_container.host is "
+            f"{postgres_from_container.host!r} (expected 'srv-captain--postgres'). "
+            f"Downstream apps may fail to connect. ====="
+        )
+
+    mappings = app.get("ports") or []
+    host_ports = [
+        int(m["hostPort"])
+        for m in mappings
+        if int(m.get("containerPort", 0)) == postgres_from_container.port
+    ]
+    if host_ports and postgres_from_vm.port not in host_ports:
+        logger.warn(
+            f"===== Deployed `postgres` app maps host port(s) {host_ports} -> "
+            f"{postgres_from_container.port}, but from_vm.port="
+            f"{postgres_from_vm.port} in YAML. The script's bare-metal "
+            f"connection will likely fail. Update from_vm.port to match. ====="
+        )
+
+
 def set_memory_limit(cap, appname, memory_bytes=1610612736):
     app = cap.get_app(appname)
     new_suo = set_yaml_value(
@@ -199,9 +235,9 @@ def deploy_stack(config, gc_repository, dry_run):
         ssl=vm_ssl,
     )
 
+    pg_app_name = config["postgres"].get("app_name", "postgres")
     if config["postgres"].get("deploy", False):
         # Deploy internal PostgreSQL instance on CapRover
-        app_name = "postgres"
         postgres_variables = {
             "$$cap_pg_user": config["postgres"]["user"],
             "$$cap_pg_pass": config["postgres"]["pass"],
@@ -217,13 +253,17 @@ def deploy_stack(config, gc_repository, dry_run):
             )
             # from_vm.port sets the host-side port mapping
             cap.update_app(
-                app_name,
+                pg_app_name,
                 port_mapping=[
                     f"{postgres_from_vm.port}:{postgres_from_container.port}"
                 ],
             )
     else:
         logger.info("Using already-deployed or external PostgreSQL configuration.")
+        if not dry_run:
+            _verify_existing_postgres_app(
+                cap, pg_app_name, postgres_from_container, postgres_from_vm
+            )
 
     if not dry_run:
         with (

--- a/caprover/gc-stack-deploy/src/gc_stack_deploy/stack_deploy.py
+++ b/caprover/gc-stack-deploy/src/gc_stack_deploy/stack_deploy.py
@@ -167,7 +167,34 @@ def deploy_stack(config, gc_repository, dry_run):
     )
     webapps_ssl = config.get("webappsUseSsl", True)
 
-    # Deploy PostgreSQL if specified in config
+    # Resolve the two Postgres connection configs.
+    if config["postgres"].get("deploy", False):
+        # We control the deploy: the one-click Postgres has no SSL configured,
+        # so any `ssl` field in YAML is ignored to avoid foot-guns.
+        container_ssl = vm_ssl = False
+    else:
+        container_ssl = bool(config["postgres"]["from_container"]["ssl"])
+        vm_ssl = bool(config["postgres"]["from_vm"]["ssl"])
+
+    # this is the connection to be used by inter-container networking:
+    # i.e. how other CapRover apps reach Postgres. Used in connection strings.
+    postgres_from_container = PostgresConnectionConfig(
+        host=config["postgres"]["from_container"]["host"],
+        port=int(config["postgres"]["from_container"]["port"]),
+        user=config["postgres"]["user"],
+        password=config["postgres"]["pass"],
+        ssl=container_ssl,
+    )
+    # this is the connection to be used from this script (which runs on the host).
+    # Used for one-time setup of databases, users, etc.
+    postgres_from_vm = PostgresConnectionConfig(
+        host=config["postgres"]["from_vm"]["host"],
+        port=int(config["postgres"]["from_vm"]["port"]),
+        user=config["postgres"]["user"],
+        password=config["postgres"]["pass"],
+        ssl=vm_ssl,
+    )
+
     if config["postgres"].get("deploy", False):
         # Deploy internal PostgreSQL instance on CapRover
         app_name = "postgres"
@@ -184,44 +211,15 @@ def deploy_stack(config, gc_repository, dry_run):
                 app_variables=postgres_variables,
                 automated=True,
             )
-
-        # this is the connection to be used by inter-container networking
-        postgres_from_container = PostgresConnectionConfig(
-            "srv-captain--postgres",
-            config["postgres"]["user"],
-            config["postgres"]["pass"],
-            ssl=False,
-        )
-        # this is the connection to be used from this script (which runs on the host)
-        postgres_from_vm = None
-
-        # For Docker deployments, expose the postgres server at this custom port on the VM
-        postgres_vm_port = int(config["postgres"]["expose_port"])
-        if not dry_run:
+            # from_vm.port sets the host-side port mapping
             cap.update_app(
                 app_name,
-                port_mapping=[f"{postgres_vm_port}:{postgres_from_container.port}"],
+                port_mapping=[
+                    f"{postgres_from_vm.port}:{postgres_from_container.port}"
+                ],
             )
-
-        # this is the connection to be used from this script (which runs on the host)
-        postgres_from_vm = PostgresConnectionConfig(
-            "127.0.0.1",
-            config["postgres"]["user"],
-            config["postgres"]["pass"],
-            ssl=False,
-            port=postgres_vm_port,
-        )
-
     else:
-        # Using an external PostgreSQL instance
-        logger.info("Using external PostgreSQL configuration.")
-        postgres_from_container = postgres_from_vm = PostgresConnectionConfig(
-            config["postgres"]["host"],
-            config["postgres"]["user"],
-            config["postgres"]["pass"],
-            ssl=True,
-            port=config["postgres"]["port"],
-        )
+        logger.info("Using already-deployed or external PostgreSQL configuration.")
 
     if not dry_run:
         with (

--- a/caprover/gc-stack-deploy/src/gc_stack_deploy/stack_deploy.py
+++ b/caprover/gc-stack-deploy/src/gc_stack_deploy/stack_deploy.py
@@ -152,7 +152,11 @@ class PostgresConnectionConfig:
     port: int = 5432
 
     def connstr(self, dbname=None):
-        s = f"host={self.host} port={self.port} user={self.user} password={self.password}"
+        sslmode = "require" if self.ssl else "disable"
+        s = (
+            f"host={self.host} port={self.port} user={self.user} "
+            f"password={self.password} sslmode={sslmode}"
+        )
         if dbname:
             s += f" dbname={dbname}"
         return s

--- a/caprover/tests/stack.test.yaml
+++ b/caprover/tests/stack.test.yaml
@@ -12,9 +12,11 @@ postgres:
   from_vm:
     host: 127.0.0.1
     port: 15432   # the container will map to this port on the host VM
+    ssl: false
   from_container:
     host: srv-captain--postgres
     port: 5432
+    ssl: false
 
 redis:
   deploy: true

--- a/caprover/tests/stack.test.yaml
+++ b/caprover/tests/stack.test.yaml
@@ -9,7 +9,12 @@ postgres:
   pass: "test_pg_password"
   database: postgres
   version: 16
-  expose_port: 15432  # the container will map to this port on the host VM
+  from_vm:
+    host: 127.0.0.1
+    port: 15432   # the container will map to this port on the host VM
+  from_container:
+    host: srv-captain--postgres
+    port: 5432
 
 redis:
   deploy: true


### PR DESCRIPTION

## Goal

Fix papercuts in stack_deploy.py's handling of locally-deployed postgres:
- On script re-runs (when deploy: false)
    - the script needs to be told (in the YAML) both the in-container hostname and the from-VM hostname. Fixes a bug.
    - it should set SSL flag when connecting from VM.
- Document that the password should be URL-friendly chars only

## What I changed and why

- When resuming a run against a local caprover-hosted postgres, the single host/port pair in the YAML couldn't simultaneously serve the bare-metal script (127.0.0.1:15432) and CapRover apps (srv-captain--postgres:5432). So I split the `postgres:` connection config into `from_vm/from_container`.
   - from_vm.port also sets the host-side port mapping when `deploy: true`.

```yaml
postgres:
  deploy: true  # Use internal postgres for testing
  user: "postgres"
  pass: "test_pg_password"

  from_vm:
    host: 127.0.0.1
    port: 15432   # the container will map to this port on the host VM
    ssl: false
  from_container:
    host: srv-captain--postgres
    port: 5432
    ssl: false
```

- Made ssl an explicit YAML flag on both views. Previously it was derived from deploy, but that was buggy. Also fixed connstr() which was missing ssl.
- Warn on resume if YAML postgres conn disagrees with the deployed app. If it's wrong, the script will likely still fail a short time later, but now we are providing a helpful message just before.
- Documented char restrictions on the password to avoid easily misparsed characters in connection strings.

## How I know it works.

I've run the Caprover test suite locally to simulate a couple scenarios:

once with deploy:true then again with deploy:false, and the YAML is correct (matching example.yaml): the entire e2e test succeeds.

once with deploy:true then again with deploy:false, but the YAML is misconfigured: the script crashes, but not before showing our new error message that pinpoints exactly what is wrong.


## What I'm not doing here

Even when `deploy: false`, stack_deploy still connects to the DB to run a `CREATE DATABASE` and other user operations for Windmill . People have questioned this but it is not a bug and so I'm leaving as-is.

## LLM use disclosure
Claude Opus suggested this new YAML schema and provided an initial draft of the code. I reviewed every line (and heavily modified).
