### PR TITLE
gc-stack-deploy: Print the filebrowser password; optionally set it from config YAML

### DIFF
--- a/caprover/gc-stack-deploy/pyproject.toml
+++ b/caprover/gc-stack-deploy/pyproject.toml
@@ -4,6 +4,7 @@ version = "0.1.0"
 description = "Deploy Guardian Connector stack of apps to the (locally running) Caprover instance."
 requires-python = ">=3.9"
 dependencies = [
+    "bcrypt",
     "ruamel.yaml",
     "psycopg[binary]",
     "Caprover-API @ git+https://github.com/IamJeffG/Caprover-API.git@all-patches-2025-nov",

--- a/caprover/gc-stack-deploy/src/gc_stack_deploy/example_configs/stack.example.yaml
+++ b/caprover/gc-stack-deploy/src/gc_stack_deploy/example_configs/stack.example.yaml
@@ -83,3 +83,4 @@ comapeo-cloud:
 filebrowser:
   deploy: true
   app_name: files  # IMPORTANT so that your app doesn't get deployed as "filebrowser"
+  admin_password: "changeme"  # optional

--- a/caprover/gc-stack-deploy/src/gc_stack_deploy/stack_deploy.py
+++ b/caprover/gc-stack-deploy/src/gc_stack_deploy/stack_deploy.py
@@ -15,6 +15,7 @@ import importlib.resources
 import io
 import logging
 import os
+import secrets
 import shutil
 import socketserver
 import sys
@@ -24,6 +25,7 @@ from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass, replace
 from functools import reduce
 
+import bcrypt
 import psycopg
 from caprover_api import caprover_api
 from ruamel.yaml import YAML
@@ -498,6 +500,23 @@ def deploy_stack(config, gc_repository, dry_run):
         variables = {}
         variables = construct_app_variables(config, one_click_app_name, variables)
         logger.info(f"Deploying {one_click_app_name.capitalize()} one-click app")
+
+        admin_password = config["filebrowser"].get("admin_password")
+        generated = admin_password is None
+        if generated:
+            admin_password = secrets.token_urlsafe(16)
+        hashed_password = bcrypt.hashpw(
+            admin_password.encode("utf-8"), bcrypt.gensalt()
+        ).decode("utf-8")
+
+        if generated:
+            print("\n" + "=" * 50)
+            print(f"FILEBROWSER ADMIN PASSWORD: {admin_password}")
+            print("Save this now -- it will not be shown again.")
+            print("=" * 50 + "\n")
+        else:
+            logger.info("Filebrowser admin password set from config (username: admin)")
+
         if not dry_run:
             cap.deploy_one_click_app(
                 one_click_app_name,
@@ -522,9 +541,16 @@ def deploy_stack(config, gc_repository, dry_run):
                 ],
                 # NOTE: You will get warning pages in the filebrowser app before the `datalake` subdir is created in storage:
                 # https://github.com/ConservationMetrics/gc-deploy/pull/12#discussion_r2243697895
-                environment_variables={"FB_ROOT": "/srv/datalake"},
+                environment_variables={
+                    "FB_ROOT": "/srv/datalake",
+                    "FB_PASSWORD": hashed_password,
+                },
             )
             set_memory_limit(cap, app_name)
+            logger.info("Waiting for Filebrowser to initialize its database...")
+            time.sleep(20)  # TODO: confirm has started. Now we're just guessing.
+            # CaproverAPI doesn't support deletion of an env var, so we just set it to empty
+            cap.update_app(app_name, environment_variables={"FB_PASSWORD": ""})
 
 
 def is_local_path(path):


### PR DESCRIPTION

## Goal


Avoids the filebrowser admin password being logged only to Docker process logs, which is very easy to miss.


## What I changed and why

New behavior:
* If admin_password is set in YAML, use it; otherwise generate one.
* In either case, hash it and set it via the FB_PASSWORD env var.
* In either case, print it clearly to the gc-stack-deploy logs, which the user is sure to be seeing.

After filebrowser initializes its DB, clear FB_PASSWORD from CapRover settings.

## Screenshots
<img width="861" height="407" alt="image" src="https://github.com/user-attachments/assets/410c80b9-1e43-42bf-a5a8-b5b5b70632d4" />

## What I'm not doing here
N/A

## LLM use disclosure
Implemented by Claude