### PR TITLE
Fix double-domain service links on the landing page and add Local Contexts to the post-deployment checklist.

### DIFF
--- a/POST-DEPLOYMENT-CHECKLIST.md
+++ b/POST-DEPLOYMENT-CHECKLIST.md
@@ -49,6 +49,7 @@ It covers the manual steps that are not already automated through the scripts an
   - [ ] Twilio message template
   - [ ] GFW API key
   - [ ] GCP service account
+  - [ ] [Local Contexts](https://localcontextshub.org)
   - [ ] CoMapeo archive server
   - [ ] Oauth client credentials (for metrics)
 - [ ] Did I schedule the [`guardianconnector_metrics`](https://github.com/ConservationMetrics/gc-scripts-hub/blob/main/f/metrics/guardianconnector/README.md) script to run once a month?

--- a/caprover/INSTALL_GC_STACK.md
+++ b/caprover/INSTALL_GC_STACK.md
@@ -181,7 +181,7 @@ The `gc-stack-deploy` handles this for you, but if you are setting up the app us
 
 ### GuardianConnector Landing Page
 
-No additional steps needed, but you may want to check if all of the environmental variables (like `NUXT_COMMUNITY_NAME`, `NUXT_PUBLIC_LOGO_URL`) are set correctly post-installation.
+No additional steps needed, but you may want to check if all of the environmental variables (like `NUXT_COMMUNITY_NAME`, `NUXT_PUBLIC_LOGO_URL`) are set correctly post-installation. In particular, `NUXT_PUBLIC_DOMAIN` should be the domain suffix that follows the community alias (e.g. `guardianconnector.net`), not the full root hostname (`<alias>.guardianconnector.net`).
 
 ### Redis
 

--- a/caprover/INSTALL_GC_STACK.md
+++ b/caprover/INSTALL_GC_STACK.md
@@ -181,7 +181,9 @@ The `gc-stack-deploy` handles this for you, but if you are setting up the app us
 
 ### GuardianConnector Landing Page
 
-No additional steps needed, but you may want to check if all of the environmental variables (like `NUXT_COMMUNITY_NAME`, `NUXT_PUBLIC_LOGO_URL`) are set correctly post-installation. In particular, `NUXT_PUBLIC_DOMAIN` should be the domain suffix that follows the community alias (e.g. `guardianconnector.net`), not the full root hostname (`<alias>.guardianconnector.net`).
+`NUXT_PUBLIC_DOMAIN` should be the domain suffix that follows the community alias (for example, `guardianconnector.net`).
+
+You may also want to check if all of the other environmental variables (like `NUXT_COMMUNITY_NAME`, `NUXT_PUBLIC_LOGO_URL`) are set correctly post-installation. 
 
 ### Redis
 

--- a/caprover/one-click-apps/v4/apps/gc-landing-page.yml
+++ b/caprover/one-click-apps/v4/apps/gc-landing-page.yml
@@ -16,7 +16,6 @@ services:
       NUXT_PUBLIC_WINDMILL_ENABLED: $$cap_windmill_enabled
       NUXT_PUBLIC_EXPLORER_ENABLED: $$cap_explorer_enabled
       NUXT_PUBLIC_BASE_URL: https://$$cap_root_domain
-      NUXT_PUBLIC_DOMAIN: $$cap_root_domain
       NUXT_PUBLIC_LOGO_URL: $$cap_logo_url
       NUXT_SESSION_PASSWORD: $$cap_session_password
 

--- a/caprover/one-click-apps/v4/apps/gc-landing-page.yml
+++ b/caprover/one-click-apps/v4/apps/gc-landing-page.yml
@@ -16,6 +16,7 @@ services:
       NUXT_PUBLIC_WINDMILL_ENABLED: $$cap_windmill_enabled
       NUXT_PUBLIC_EXPLORER_ENABLED: $$cap_explorer_enabled
       NUXT_PUBLIC_BASE_URL: https://$$cap_root_domain
+      NUXT_PUBLIC_DOMAIN: ""
       NUXT_PUBLIC_LOGO_URL: $$cap_logo_url
       NUXT_SESSION_PASSWORD: $$cap_session_password
 


### PR DESCRIPTION
## Goal

Fix double-domain service links on the landing page and add Local Contexts to the post-deployment checklist.

## Screenshots


## What I changed and why




## What I'm not doing here


## LLM use disclosure

