### PR TITLE
[gc-stack-deploy] Pre-pull windmill image to avoid caprover timeouts

### DIFF
--- a/caprover/gc-stack-deploy/src/gc_stack_deploy/stack_deploy.py
+++ b/caprover/gc-stack-deploy/src/gc_stack_deploy/stack_deploy.py
@@ -22,6 +22,7 @@ import subprocess
 import sys
 import threading
 import time
+import urllib.request
 from contextlib import contextmanager, nullcontext
 from dataclasses import dataclass, replace
 from functools import reduce
@@ -201,12 +202,30 @@ class PostgresConnectionConfig:
         return s
 
 
-def _pre_pull_windmill_image(variables: dict) -> None:
+def _windmill_default_docker_image(gc_repository: str) -> str:
+    """Fetch the default Windmill docker image tag from the one-click app definition."""
+    # Mimic download one-click-app from remote repository from CaproverAPI's _download_one_click_app_defn
+    url = gc_repository + "windmill-only"
+    with urllib.request.urlopen(url) as resp:
+        raw = resp.read().decode()
+    doc = YAML().load(raw)
+    # Mimic CaproverAPI's _resolve_app_variables to find variable defaults
+    for var in doc.get("caproverOneClickApp", {}).get("variables", []):
+        if var.get("id") == "$$cap_app_docker_image":
+            default = var.get("defaultValue")
+            if default is not None:
+                return str(default)
+    raise ValueError(
+        "$$cap_app_docker_image defaultValue not found in windmill-only one-click app"
+    )
+
+
+def _pre_pull_windmill_image(variables: dict, gc_repository: str) -> None:
     # The Windmill image is large enough to cause CapRover's deploy call to time out
     # before Docker finishes pulling it. Pre-pulling here ensures it is cached.
-    # Keep WINDMILL_DEFAULT_IMAGE in sync with windmill-only.yml $$cap_app_docker_image defaultValue.
-    WINDMILL_DEFAULT_IMAGE = "ghcr.io/windmill-labs/windmill:1.704.1"
-    image = variables.get("$$cap_app_docker_image", WINDMILL_DEFAULT_IMAGE)
+    image = variables.get("$$cap_app_docker_image") or _windmill_default_docker_image(
+        gc_repository
+    )
     logger.info(f"Pre-pulling Windmill image {image!r} to avoid CapRover timeout ...")
     subprocess.run(["docker", "pull", image], check=True)
     logger.info("Windmill image pre-pull complete.")
@@ -316,7 +335,7 @@ def deploy_stack(config, gc_repository, dry_run):
         logger.info(f"Deploying {one_click_app_name.capitalize()} one-click app")
 
         # Hacky workaround: pre-pull large Windmill image to avoid CapRover timeout
-        _pre_pull_windmill_image(variables)
+        _pre_pull_windmill_image(variables, gc_repository)
 
         if not dry_run:
             # As superadmin, create a windmill database

--- a/caprover/gc-stack-deploy/src/gc_stack_deploy/stack_deploy.py
+++ b/caprover/gc-stack-deploy/src/gc_stack_deploy/stack_deploy.py
@@ -18,6 +18,7 @@ import os
 import secrets
 import shutil
 import socketserver
+import subprocess
 import sys
 import threading
 import time
@@ -200,6 +201,17 @@ class PostgresConnectionConfig:
         return s
 
 
+def _pre_pull_windmill_image(variables: dict) -> None:
+    # The Windmill image is large enough to cause CapRover's deploy call to time out
+    # before Docker finishes pulling it. Pre-pulling here ensures it is cached.
+    # Keep WINDMILL_DEFAULT_IMAGE in sync with windmill-only.yml $$cap_app_docker_image defaultValue.
+    WINDMILL_DEFAULT_IMAGE = "ghcr.io/windmill-labs/windmill:1.704.1"
+    image = variables.get("$$cap_app_docker_image", WINDMILL_DEFAULT_IMAGE)
+    logger.info(f"Pre-pulling Windmill image {image!r} to avoid CapRover timeout ...")
+    subprocess.run(["docker", "pull", image], check=True)
+    logger.info("Windmill image pre-pull complete.")
+
+
 def deploy_stack(config, gc_repository, dry_run):
     """Deploy application stack based on the configuration file."""
 
@@ -302,6 +314,9 @@ def deploy_stack(config, gc_repository, dry_run):
         variables = construct_app_variables(config, one_click_app_name, variables)
 
         logger.info(f"Deploying {one_click_app_name.capitalize()} one-click app")
+
+        # Hacky workaround: pre-pull large Windmill image to avoid CapRover timeout
+        _pre_pull_windmill_image(variables)
 
         if not dry_run:
             # As superadmin, create a windmill database

--- a/caprover/one-click-apps/v4/apps/windmill-only.yml
+++ b/caprover/one-click-apps/v4/apps/windmill-only.yml
@@ -120,7 +120,7 @@ caproverOneClickApp:
   variables:
     - id: $$cap_app_docker_image
       label: Windmill Docker Image
-      defaultValue: "ghcr.io/windmill-labs/windmill:1.691.1"
+      defaultValue: "ghcr.io/windmill-labs/windmill:1.704.1"  # when you bump this, also bump it in stack_deploy.py
       description: Checkout their github page for the valid tags https://github.com/windmill-labs/windmill/releases
 
     - id: $$cap_database_url

--- a/caprover/one-click-apps/v4/apps/windmill-only.yml
+++ b/caprover/one-click-apps/v4/apps/windmill-only.yml
@@ -120,7 +120,7 @@ caproverOneClickApp:
   variables:
     - id: $$cap_app_docker_image
       label: Windmill Docker Image
-      defaultValue: "ghcr.io/windmill-labs/windmill:1.704.1"  # when you bump this, also bump it in stack_deploy.py
+      defaultValue: "ghcr.io/windmill-labs/windmill:1.704.1"
       description: Checkout their github page for the valid tags https://github.com/windmill-labs/windmill/releases
 
     - id: $$cap_database_url


### PR DESCRIPTION

## Goal

First-time run of gc-stack-deploy times out EVERY TIME waiting on the Windmill image.  This will pre-pull windmill image to avoid caprover timeouts, and avoid the script crashing.


## Screenshots
<img width="1129" height="201" alt="image" src="https://github.com/user-attachments/assets/0da13a54-b7b9-4ebf-ba68-fdaa11108dc9" />


## Why I'm convinced it works
I ran the e2e test suite locally and saw it download the correct image version before deployment.

## What I changed and why

To fix the script to better handle timeouts is not realistic due to how the upstream CaproverAPI dependency handles timeouts.

Instead we do a hacky-workaround: when `windmill.deploy == True` the first thing we do (before touching CapRover) is a manual `docker pull` of the image. This will not timeout.


I am also taking this opportunity to bump the version of windmill we will install.

## What I'm not doing here

As it is now, we need to manually keep the docker images synced between the one-click-app and `stack_deploy.py`. We could have parsed the one-click-app defn to get the `$cap_app_docker_image`.

## LLM use disclosure

Code written by Claude.

Tested by me, commit and PR messages written by me.